### PR TITLE
feat: support more case options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,9 +3,19 @@
 version = 3
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "enum_stringify"
 version = "0.5.0"
 dependencies = [
+ "convert_case",
  "proc-macro2",
  "quote",
  "serde",
@@ -66,3 +76,9 @@ name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ proc-macro = true
 proc-macro2 = "1.0.82"
 quote = "1.0.36"
 syn = "2.0.63"
+convert_case = "0.6.0"
 
 [dev-dependencies]
 serde = { version = "1.0.202", features = ["derive"] }

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use convert_case::Casing;
 use proc_macro2::{Ident, TokenStream};
 use syn::{DeriveInput, Meta};
 
@@ -11,10 +12,7 @@ fn parse_string(s: &str) -> Result<String, ()> {
     }
 }
 
-pub(crate) enum Case {
-    Lower,
-    Upper,
-}
+pub(crate) struct Case(convert_case::Case);
 
 impl TryFrom<(String, String)> for Case {
     type Error = ();
@@ -32,11 +30,26 @@ impl TryFrom<String> for Case {
     type Error = ();
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
-        Ok(match value.as_str() {
-            "\"lower\"" => Self::Lower,
-            "\"upper\"" => Self::Upper,
+        Ok(Self(match value.as_str() {
+            "\"upper\"" => convert_case::Case::Upper,
+            "\"lower\"" => convert_case::Case::Lower,
+            "\"title\"" => convert_case::Case::Title,
+            "\"toggle\"" => convert_case::Case::Toggle,
+            "\"camel\"" => convert_case::Case::Camel,
+            "\"pascal\"" => convert_case::Case::Pascal,
+            "\"upper_camel\"" => convert_case::Case::UpperCamel,
+            "\"snake\"" => convert_case::Case::Snake,
+            "\"upper_snake\"" => convert_case::Case::UpperSnake,
+            "\"screaming_snake\"" => convert_case::Case::ScreamingSnake,
+            "\"kebab\"" => convert_case::Case::Kebab,
+            "\"cobol\"" => convert_case::Case::Cobol,
+            "\"upper_kebab\"" => convert_case::Case::UpperKebab,
+            "\"train\"" => convert_case::Case::Train,
+            "\"flat\"" => convert_case::Case::Flat,
+            "\"upper_flat\"" => convert_case::Case::UpperFlat,
+            "\"alternating\"" => convert_case::Case::Alternating,
             _ => Err(())?,
-        })
+        }))
     }
 }
 
@@ -235,10 +248,7 @@ impl Attributes {
             }
 
             if let Some(case) = &self.case {
-                new_name = match case {
-                    Case::Lower => new_name.to_lowercase(),
-                    Case::Upper => new_name.to_uppercase(),
-                };
+                new_name = new_name.to_case(case.0);
             }
 
             new_names.push(new_name);

--- a/tests/attributes.rs
+++ b/tests/attributes.rs
@@ -68,7 +68,7 @@ fn test_prefix_suffix_from_str() {
 // Testing commutativity of prefix, suffix and case
 
 #[derive(Debug, PartialEq, enum_stringify::EnumStringify)]
-#[enum_stringify(suffix = "Suff", prefix = "Pref", case = "lower")]
+#[enum_stringify(suffix = "Suff", prefix = "Pref", case = "flat")]
 enum Number4 {
     Zero,
     One,
@@ -76,21 +76,21 @@ enum Number4 {
 }
 
 #[test]
-fn test_suffix_prefix_lower_to_string() {
+fn test_suffix_prefix_flat_to_string() {
     assert_eq!(Number4::Zero.to_string(), "prefzerosuff");
     assert_eq!(Number4::One.to_string(), "prefonesuff");
     assert_eq!(Number4::Two.to_string(), "preftwosuff");
 }
 
 #[test]
-fn test_suffix_prefix_lower_from_str() {
+fn test_suffix_prefix_flat_from_str() {
     assert_eq!(Number4::from_str("prefzerosuff"), Ok(Number4::Zero));
     assert_eq!(Number4::from_str("prefonesuff"), Ok(Number4::One));
     assert_eq!(Number4::from_str("preftwosuff"), Ok(Number4::Two));
 }
 
 #[derive(Debug, PartialEq, enum_stringify::EnumStringify)]
-#[enum_stringify(suffix = "Suff", prefix = "Pref", case = "upper")]
+#[enum_stringify(suffix = "Suff", prefix = "Pref", case = "upper_flat")]
 enum Number5 {
     Zero,
     One,
@@ -98,14 +98,14 @@ enum Number5 {
 }
 
 #[test]
-fn test_suffix_prefix_upper_to_string() {
+fn test_suffix_prefix_upper_flat_to_string() {
     assert_eq!(Number5::Zero.to_string(), "PREFZEROSUFF");
     assert_eq!(Number5::One.to_string(), "PREFONESUFF");
     assert_eq!(Number5::Two.to_string(), "PREFTWOSUFF");
 }
 
 #[test]
-fn test_suffix_prefix_upper_from_str() {
+fn test_suffix_prefix_upper_flat_from_str() {
     assert_eq!(Number5::from_str("PREFZEROSUFF"), Ok(Number5::Zero));
     assert_eq!(Number5::from_str("PREFONESUFF"), Ok(Number5::One));
     assert_eq!(Number5::from_str("PREFTWOSUFF"), Ok(Number5::Two));


### PR DESCRIPTION
Hey, nice library! I was just about to write my own stringifier, but then I discovered this existed. Unfortunately, it doesn't support _everything_ I needed. Specifically, the case conversion. So I added some more. I was originally going to write them by hand, but then I discovered that [this](https://github.com/rutrum/convert-case) exists, so I just based it on that.

One downside of doing it like this is what was formerly "lower" and "upper" are now "flat" and "upper_flat". Let me know if you don't like this or whatever.