### PR TITLE
feat: error as string

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@ mod attributes;
 /// }
 ///
 /// impl TryFrom<&str> for Numbers {
-///     type Error = ();
+///     type Error = String;
 ///
 ///     fn try_from(s: &str) -> Result<Self, Self::Error> {
 ///         match s {    
@@ -149,7 +149,7 @@ mod attributes;
 /// }
 ///
 /// impl TryFrom<String> for Numbers {
-///     type Error = ();
+///     type Error = String;
 ///         
 ///     fn try_from(s: String) -> Result<Self, Self::Error> {
 ///         s.as_str().try_into()
@@ -157,7 +157,7 @@ mod attributes;
 /// }
 ///
 /// impl ::std::str::FromStr for Numbers {
-///     type Err = ();
+///     type Err = String;
 ///
 ///     fn from_str(s: &str) -> Result<Self, Self::Err> {
 ///         s.try_into()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,13 @@ mod attributes;
 ///         match s {    
 ///             "One" => Ok(Self::One),
 ///             "Two" => Ok(Self::Two),
-///             _ => Err(()),
+///             _ => {
+///                 let mut err_msg = "Failed parse string ".to_string();
+///                 err_msg.push_str(s);
+///                 err_msg.push_str(" for enum ");
+///                 err_msg.push_str("Numbers");
+///                 Err(err_msg)
+///             }
 ///         }
 ///     }
 /// }
@@ -207,14 +213,21 @@ fn impl_from_str(
     identifiers: &Vec<&syn::Ident>,
     names: &Vec<String>,
 ) -> TokenStream {
+    let name_str = name.to_string();
     let gen = quote! {
         impl TryFrom<&str> for #name {
-            type Error = ();
+            type Error = String;
 
             fn try_from(s: &str) -> Result<Self, Self::Error> {
                 match s {
                     #(#names => Ok(Self::#identifiers),)*
-                    _ => Err(()),
+                    _ => {
+                        let mut err_msg = "Failed parse string ".to_string();
+                        err_msg.push_str(s);
+                        err_msg.push_str(" for enum ");
+                        err_msg.push_str(#name_str);
+                        Err(err_msg)
+                    }
                 }
             }
         }
@@ -227,7 +240,7 @@ fn impl_from_str(
 fn impl_from_string(name: &syn::Ident) -> TokenStream {
     let gen = quote! {
         impl TryFrom<String> for #name {
-            type Error = ();
+            type Error = String;
 
             fn try_from(s: String) -> Result<Self, Self::Error> {
                 s.as_str().try_into()
@@ -242,7 +255,7 @@ fn impl_from_string(name: &syn::Ident) -> TokenStream {
 fn impl_from_str_trait(name: &syn::Ident) -> TokenStream {
     let gen = quote! {
         impl ::std::str::FromStr for #name {
-            type Err = ();
+            type Err = String;
 
             fn from_str(s: &str) -> Result<Self, Self::Err> {
                 s.try_into()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,6 @@ mod attributes;
 ///     }
 /// }
 /// ```
-
 #[proc_macro_derive(EnumStringify, attributes(enum_stringify))]
 pub fn enum_stringify(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);


### PR DESCRIPTION
The advantage is that, unlike `()`, `String` implements `Display`. I get that you made it `()` to avoid having a library that users have to depend on at runtime, but this should be a fair compromise.

Makes it easier to do debugging (and some libraries want error types to necessarily implement `Display`).

P.S.: just realized that in my previous PR (#41) I forgot to update the README and docs accordingly. You should probably do that. Or I can, if you prefer, I don't mind.