### PR TITLE
docs: updated docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ variants and also changing the case of the string representation.
 use enum_stringify::EnumStringify;
 
 #[derive(EnumStringify)]
-#[enum_stringify(prefix = "MyPrefix", suffix = "MySuffix", case = "upper")]
+#[enum_stringify(prefix = "MyPrefix", suffix = "MySuffix", case = "upper_flat")]
 enum MyEnum {
     Variant1,
     Variant2,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,10 @@ mod attributes;
 ///
 /// # Case
 ///
-/// You can also set the case ("lower" or "upper") of the string representation of the enum variants.
+/// You can also set the case of the string representation of the enum variants.
+/// Case conversion is provided by the [`convert_case`] crate. Refer to the variants
+/// of the [`convert_case::Case`] enum for options (expressed in lower snake case).
+/// The exception are the `Random` and `PseudoRandom` variants, which are not accepted.
 ///
 /// ```
 /// use enum_stringify::EnumStringify;


### PR DESCRIPTION
Forgot to update docs in #41.

I actually don't know if it's legal to link to another crate's docs as I did here for the `Case` enum. Let me know if crates.io rejects this or whatever.